### PR TITLE
Randotorio rewrite

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -429,14 +429,6 @@ function rando.BFSStep(iter)
 		rando.thing_automatable["item:" .. item] = true
 	end
 
-	-- Update lab pack status, because apparently you cannot research anything if you crafted tech packs before placing a lab
-	for item, itemdata in pairs(hand.itemscan) do
-		if (type(itemdata) == "table" and itemdata.labpack == false and hand.labslots[item]) then
-			itemdata.labpack = true 
-			logic.PushLabPack(proto.RawItem(item))
-		end
-	end
-
 	if (table_size(rando.recipe_queue) == 0) then
 		for k, e in pairs(rando.unaffordable_recipe_queue) do
 			if (not rando.queued[e.name] and logic.CanAffordRecipe(e) and logic.CanCraftRecipe(e)) then
@@ -672,6 +664,14 @@ function rando.BFSStep(iter)
 	logic.ScanTechnologies()
 	logic.ScanEntities()
 	logic.ScanResources()
+
+	-- Update lab pack status, because apparently you cannot research anything if you crafted tech packs before placing a lab
+	for item, itemdata in pairs(hand.itemscan) do
+		if (type(itemdata) == "table" and itemdata.labpack == false and hand.labslots[item]) then
+			itemdata.labpack = true 
+			logic.PushLabPack(proto.RawItem(item))
+		end
+	end
 
 	-- Also unlock technologies manually, because it only checks hand
 	for k,v in pairs(data.raw.technology) do

--- a/info.json
+++ b/info.json
@@ -5,6 +5,6 @@
 	"author": "PyroFire",
 	"dependencies": ["base >= 0.18","? SeaBlock","? spaceblock"],
 	"description": "Factorio but every recipe is randomized",
-	"factorio_version": "0.18",
+	"factorio_version": "1.1",
 	"homepage":"none"
 }


### PR DESCRIPTION
Rewrote randomization logic because could not understand the old one.
Highlights:
- recipes are checked one at a time. On each iteration, one recipe is picked among the ones that would be craftable naturally.
- if the recipe is automatable normally, only automatable ingredients will be available for it. This nicely phases out early wood.
- the code ensures that only one recipe from each crafting category (only among the recipes with one ingredient) would ever get any given ingredient. This solves the problem with furnaces, but there might be some modded furnaces that can smelt several categories (so, this is not an ultimate fix).
- the code keeps in mind the initial costs of items and tries to stay close to them. Resources are priced at 1 while fluids are 0.02 per unit.
- some things from the data lib are fixed indirectly. Most notable one is the fact that if a lab pack is added to hand before its lab, then it will receive labpack = false and never get to be rechecked.

This should close 2.5 out of 4 flaws.

There are some magic constants, you might want to move them into settings. Did not test compatibility with mods, only vanilla. The code spams into the log, this can be commented out. The old code is preserved and can still do some things in the background. logic.debug is not changed to return new variables. The whole code should have an asymptotic about O(n^2); you might want to come up with a way to get new hand status changes faster, if it becomes a problem.